### PR TITLE
Make the library compile on stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "web-extensions"
 version = "0.1.0"
-authors = ["Roman Volosatovs <rvolosatovs@riseup.net>"]
-edition = "2018"
+authors = [
+  "Roman Volosatovs <rvolosatovs@riseup.net>",
+  "Markus Kohlhase <markus.kohlhase@slowtec.de>",
+]
+edition = "2021"
 description = "This crate provides wrappers around WebExtensions API"
 repository = "https://github.com/rvolosatovs/web-extensions"
 license = "MIT"
@@ -13,13 +16,13 @@ categories = ["api-bindings", "wasm"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-js-sys = "0.3.44"
-serde = { version = "1.0.115", features = ["derive"] }
-serde_derive = "1.0.115"
-serde_json = "1.0.57"
-wasm-bindgen = { version = "0.2.67", features = ["serde-serialize", "nightly"] }
-wasm-bindgen-futures = "0.4.17"
-web-extensions-sys = { version = "0.1.0" }
+js-sys = "0.3.59"
+serde = { version = "1.0.142", features = ["derive"] }
+serde_derive = "1.0.142"
+serde_json = "1.0.83"
+wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
+wasm-bindgen-futures = "0.4.32"
+web-extensions-sys = "0.2.0"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.13"
+wasm-bindgen-test = "0.3.32"

--- a/src/contextual_identities.rs
+++ b/src/contextual_identities.rs
@@ -1,15 +1,13 @@
 use crate::{js_from_serde, object_from_js, serde_from_js_result, Error};
 
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
-use wasm_bindgen::prelude::*;
 use web_extensions_sys::{browser, ContextualIdentities};
 
 fn contextual_identities() -> ContextualIdentities {
     browser.contextual_identities()
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Color {
     #[serde(rename(serialize = "blue", deserialize = "blue"))]
     Blue,
@@ -31,7 +29,7 @@ pub enum Color {
     Toolbar,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Icon {
     #[serde(rename(serialize = "fingerprint", deserialize = "fingerprint"))]
     Fingerprint,
@@ -61,7 +59,7 @@ pub enum Icon {
     Fence,
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ContextualIdentity {
     pub cookie_store_id: String,

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -1,27 +1,11 @@
-use std::marker::Unsize;
-use wasm_bindgen::closure::WasmClosure;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{closure::WasmClosure, prelude::*, JsCast};
+use web_extensions_sys as sys;
 
 // Adapted from https://github.com/rustwasm/gloo/blob/2c9e776701ecb90c53e62dec1abd19c2b70e47c7/crates/events/src/lib.rs#L232-L582
 #[must_use = "event listener will never be called after being dropped"]
 pub struct EventListener<'a, F: ?Sized> {
-    target: &'a web_extensions_sys::EventTarget,
+    target: &'a sys::EventTarget,
     callback: Option<Closure<F>>,
-}
-
-impl<'a, F> EventListener<'a, F>
-where
-    F: ?Sized,
-{
-    #[inline]
-    fn raw_new(target: &'a web_extensions_sys::EventTarget, callback: Closure<F>) -> Self {
-        target.add_listener(callback.as_ref().unchecked_ref());
-        Self {
-            target,
-            callback: Some(callback),
-        }
-    }
 }
 
 impl<'a, F> EventListener<'a, F>
@@ -29,11 +13,12 @@ where
     F: ?Sized + WasmClosure,
 {
     #[inline]
-    pub fn new<L>(target: &'a web_extensions_sys::EventTarget, callback: L) -> Self
-    where
-        L: Unsize<F> + 'static,
-    {
-        Self::raw_new(target, Closure::new(callback))
+    pub(crate) fn raw_new(target: &'a sys::EventTarget, callback: Closure<F>) -> Self {
+        target.add_listener(callback.as_ref().unchecked_ref());
+        Self {
+            target,
+            callback: Some(callback),
+        }
     }
 
     /// Keeps the `EventListener` alive forever, so it will never be dropped.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,6 @@
-#![feature(unsize)]
-#![feature(unboxed_closures)]
-
 use js_sys::Object;
-use std::fmt::Debug;
-use std::marker::PhantomData;
-use std::marker::Unsize;
-use wasm_bindgen::closure::WasmClosure;
-use wasm_bindgen::convert::FromWasmAbi;
-use wasm_bindgen::describe::WasmDescribe;
-use wasm_bindgen::prelude::*;
+use std::{fmt::Debug, marker::PhantomData};
+use wasm_bindgen::{convert::FromWasmAbi, describe::WasmDescribe, prelude::*};
 
 pub mod contextual_identities;
 pub mod tabs;
@@ -18,16 +10,6 @@ mod event_listener;
 pub use event_listener::*;
 
 pub struct EventTarget<A>(web_extensions_sys::EventTarget, PhantomData<A>);
-
-impl<A> EventTarget<A> {
-    pub fn add_listener<L, W>(&self, listener: L) -> EventListener<W>
-    where
-        W: ?Sized + WasmClosure + FnMut<A>,
-        L: FnMut<A> + Unsize<W> + 'static,
-    {
-        EventListener::new(&self.0, listener)
-    }
-}
 
 #[derive(Debug)]
 pub enum Error {


### PR DESCRIPTION
I'd like to use this library with stable Rust, 
so we need a way to handle the event listeners without `#![feature(unsize)]` and `#![feature(unboxed_closures)]`.